### PR TITLE
Fix running tests

### DIFF
--- a/JavaScript/1-stub/runner.js
+++ b/JavaScript/1-stub/runner.js
@@ -10,22 +10,16 @@ const start = (tests) => {
     }
     const test = tests.shift();
     console.log(`Started test: ${test.name}`);
-    try {
-      test((err) => {
-        if (err) {
-          failed++;
-          console.log(`Failed test: ${test.name}`);
-          console.log(err);
-        }
+    test((err) => {
+      if (err) {
+        failed++;
+        console.log(`Failed test: ${test.name}`);
+        console.log(err);
+      } else {
         console.log(`Finished test: ${test.name}`);
-        setTimeout(runNext, 0);
-      });
-    } catch (err) {
-      failed++;
-      console.log(`Failed test: ${test.name}`);
-      console.log(err);
+      }
       setTimeout(runNext, 0);
-    }
+    });
   };
   runNext();
 };

--- a/JavaScript/1-stub/tests.js
+++ b/JavaScript/1-stub/tests.js
@@ -9,7 +9,6 @@ const runner = require('./runner.js');
 const testCreateTask = (next) => {
   const timer = setTimeout(() => {
     const err = new Error('Can not create task');
-    assert.fail(err);
     next(err);
   }, 200);
 
@@ -33,7 +32,6 @@ const testCreateTask = (next) => {
 const testExecuteTask = (next) => {
   const timer = setTimeout(() => {
     const err = new Error('Can not execute task');
-    assert.fail(err);
     next(err);
   }, 200);
 
@@ -57,7 +55,6 @@ const testExecuteTask = (next) => {
 const testFailedTask = (next) => {
   const timer = setTimeout(() => {
     const err = new Error('Task expected to fail');
-    assert.fail(err);
     next(err);
   }, 200);
 
@@ -74,10 +71,11 @@ const testFailedTask = (next) => {
       assert.strictEqual(err.message, 'Task failed');
     } catch (err) {
       error = err;
+    } finally {
+      clearTimeout(timer);
+      scheduler.stopAll();
+      next(error);
     }
-    clearTimeout(timer);
-    scheduler.stopAll();
-    next(error);
   });
 };
 


### PR DESCRIPTION
The try-catch in Runner, which was set for debugging asynchronous functions, has been removed and changed to comply with the callback contract.

Previous output:
```bash
Started test: testCreateTask
Finished test: testCreateTask
Started test: testExecuteTask
Started test: testFailedTask
Total: 3; Failed: 0
```

New output:
```bash
Started test: testCreateTask
Finished test: testCreateTask
Started test: testExecuteTask
Finished test: testExecuteTask
Started test: testFailedTask
Finished test: testFailedTask
Total: 3; Failed: 0
```
